### PR TITLE
populate icon component's content if template key is present in icon dict

### DIFF
--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -27,7 +27,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <text v-if="item.icon.template">{{ item.icon.template }}</text>
+            <template v-if="item.icon.template">{{ item.icon.text }}</template>
           </component>
         </template>
         <template v-if="!isCollapsed">
@@ -72,7 +72,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <text v-if="item.icon.template">{{ item.icon.template }}</text>
+            <template v-if="item.icon.template">{{ item.icon.text }}</template>
           </component>
         </template>
         <template v-if="!isCollapsed">

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -27,7 +27,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+            <text v-if="item.icon.template">{{ item.icon.template }}</text>
           </component>
         </template>
         <template v-if="!isCollapsed">
@@ -72,7 +72,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+            <text v-if="item.icon.template">{{ item.icon.template }}</text>
           </component>
         </template>
         <template v-if="!isCollapsed">

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -26,7 +26,9 @@
             class="vsm-icon"
             :class="item.icon.class"
             v-bind="item.icon.attributes"
-          />
+          >
+            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+          </component>
         </template>
         <template v-if="!isCollapsed">
           <component
@@ -69,7 +71,9 @@
             class="vsm-icon"
             :class="item.icon.class"
             v-bind="item.icon.attributes"
-          />
+          >
+            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+          </component>
         </template>
         <template v-if="!isCollapsed">
           <component

--- a/src/components/MobileItem.vue
+++ b/src/components/MobileItem.vue
@@ -25,7 +25,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <text v-if="item.icon.template">{{ item.icon.template }}</text>
+            <template v-if="item.icon.template">{{ item.icon.text }}</template>
           </component>
         </template>
         <component
@@ -65,7 +65,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <text v-if="item.icon.template">{{ item.icon.template }}</text>
+            <template v-if="item.icon.template">{{ item.icon.text }}</template>
           </component>
         </template>
         <component

--- a/src/components/MobileItem.vue
+++ b/src/components/MobileItem.vue
@@ -25,7 +25,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+            <text v-if="item.icon.template">{{ item.icon.template }}</text>
           </component>
         </template>
         <component
@@ -65,7 +65,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+            <text v-if="item.icon.template">{{ item.icon.template }}</text>
           </component>
         </template>
         <component

--- a/src/components/MobileItem.vue
+++ b/src/components/MobileItem.vue
@@ -24,7 +24,9 @@
             class="vsm-icon"
             :class="item.icon.class"
             v-bind="item.icon.attributes"
-          />
+          >
+            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+          </component>
         </template>
         <component
           :is="item.badge.element ? item.badge.element : 'span'"
@@ -62,7 +64,9 @@
             class="vsm-icon"
             :class="item.icon.class"
             v-bind="item.icon.attributes"
-          />
+          >
+            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+          </component>
         </template>
         <component
           :is="item.badge.element ? item.badge.element : 'span'"

--- a/src/components/SubItem.vue
+++ b/src/components/SubItem.vue
@@ -25,7 +25,9 @@
             class="vsm-icon"
             :class="item.icon.class"
             v-bind="item.icon.attributes"
-          />
+          >
+            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+          </component>
         </template>
         <component
           :is="item.badge.element ? item.badge.element : 'span'"
@@ -66,7 +68,9 @@
             class="vsm-icon"
             :class="item.icon.class"
             v-bind="item.icon.attributes"
-          />
+          >
+            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+          </component>
         </template>
         <component
           :is="item.badge.element ? item.badge.element : 'span'"

--- a/src/components/SubItem.vue
+++ b/src/components/SubItem.vue
@@ -26,7 +26,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <text v-if="item.icon.template">{{ item.icon.template }}</text>
+            <template v-if="item.icon.template">{{ item.icon.text }}</template>
           </component>
         </template>
         <component
@@ -69,7 +69,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <text v-if="item.icon.template">{{ item.icon.template }}</text>
+            <template v-if="item.icon.template">{{ item.icon.text }}</template>
           </component>
         </template>
         <component

--- a/src/components/SubItem.vue
+++ b/src/components/SubItem.vue
@@ -26,7 +26,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+            <text v-if="item.icon.template">{{ item.icon.template }}</text>
           </component>
         </template>
         <component
@@ -69,7 +69,7 @@
             :class="item.icon.class"
             v-bind="item.icon.attributes"
           >
-            <template v-if="item.icon.template">{{ item.icon.template }}</template>
+            <text v-if="item.icon.template">{{ item.icon.template }}</text>
           </component>
         </template>
         <component


### PR DESCRIPTION
I was testing vue-sidebar-menu when I realized I couldn't use font icon libraries that make use of typographic ligatures. I created this pull request to solve [this issue](https://github.com/yaminncco/vue-sidebar-menu/issues/55).