### PR TITLE
added the inclusion of css in demo and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Or import the component locally.
 ```js
 //App.vue
 import { SidebarMenu } from 'vue-sidebar-menu'
+import 'vue-sidebar-menu/dist/vue-sidebar-menu.css'
 export default {
   components: {
     SidebarMenu

--- a/demo/src/components/Installation.vue
+++ b/demo/src/components/Installation.vue
@@ -18,7 +18,8 @@ app.mount("#app")` }}
     </prism-code>
     <p>Or import the component locally.</p>
     <prism-code lang="js">
-      {{ `import { SidebarMenu } from 'vue-sidebar-menu'
+      {{ `import { SidebarMenu } from 'vue-sidebar-menu'	  
+import 'vue-sidebar-menu/dist/vue-sidebar-menu.css'
 export default {
   components: {
     SidebarMenu


### PR DESCRIPTION
I don't know if I did something wrong or just misread something in the README, but I had to include the css file when trying to include the component locally, so i thought it would be useful to add it to the documentation .