### PR TITLE
Update README to include custom styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,12 +273,13 @@ All styles customization can be done in normal CSS by using this classes
 .v-sidebar-menu .vsm--toggle-btn {}
 ```
 
-or you can override Sass variables (complete list of all variables can be found in `src/scss/_variables.scss`) and create your own theme
+or you can override Sass variables (complete list of all variables can be found in `src/scss/_variables.scss`) and create your own theme. To include your theme add the following lines and make sure to not set a 'selectedTheme' (eg. `selectedTheme: 'white-theme'`) since this will set some of the color variables.
 
 ```scss
 @import "custom-var.scss";
 @import "vue-sidebar-menu/src/scss/vue-sidebar-menu.scss";
 ```
+
 
 ## Slots
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ All styles customization can be done in normal CSS by using this classes
 .v-sidebar-menu .vsm--toggle-btn {}
 ```
 
-or you can override Sass variables (complete list of all variables can be found in `src/scss/_variables.scss`) and create your own theme. To include your theme add the following lines and make sure to not set a 'selectedTheme' (eg. `selectedTheme: 'white-theme'`) since this will set some of the color variables.
+or you can override Sass variables (complete list of all variables can be found in `src/scss/_variables.scss`) and create your own theme. Make sure to set prop `theme` to default value.
 
 ```scss
 @import "custom-var.scss";


### PR DESCRIPTION
I struggled a bit to add custom colours until I noticed, that I had to remove the `selectedTheme`.
Therefore, I included a part in the README to explain what steps need to be done to use custom colours.


