### PR TITLE
added tooltip when item is hovered

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ menu [
         you can mark link as external
         // external: true
         */
-       
+
         title: 'Dashboard',
 
         // icon class
@@ -106,7 +106,7 @@ menu [
             // element: 'span'
         }
         */
-        
+
         // child: []
         // disabled: true
         // class: ''
@@ -209,6 +209,12 @@ props: {
     disableHover: {
       type: Boolean,
       default: false
+    },
+
+    // show title as a tooltip when sidebar is collapsed and item is hovered
+    hasTooltip: {
+      type: Boolean,
+      default: true
     }
 }
 ```

--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -26,6 +26,7 @@
           :rtl="rtl"
           :mobile-item="mobileItem"
           :disable-hover="disableHover"
+          :has-tooltip="hasTooltip"
           @set-mobile-item="setMobileItem"
           @unset-mobile-item="unsetMobileItem"
         >
@@ -128,6 +129,10 @@ export default {
     disableHover: {
       type: Boolean,
       default: false
+    },
+    hasTooltip: {
+      type: Boolean,
+      default: true
     }
   },
   data () {

--- a/src/components/SidebarMenuItem.vue
+++ b/src/components/SidebarMenuItem.vue
@@ -34,7 +34,9 @@
         :appear="isMobileItem"
       >
         <template v-if="(isCollapsed && !isFirstLevel) || !isCollapsed || isMobileItem">
-          <span class="vsm--title">{{ item.title }}</span>
+          <span class="vsm--title" :title="isCollapsed && hasTooltip ? item.title : ''" >
+            {{ item.title }}
+          </span>
         </template>
       </transition>
       <template v-if="(isCollapsed && !isFirstLevel) || !isCollapsed || isMobileItem">
@@ -145,6 +147,10 @@ export default {
     mobileItemStyle: {
       type: Object,
       default: null
+    },
+    hasTooltip: {
+      type: Boolean,
+      default: true
     }
   },
   data () {

--- a/src/components/SidebarMenuItem.vue
+++ b/src/components/SidebarMenuItem.vue
@@ -22,6 +22,8 @@
     <sidebar-menu-link
       :item="item"
       :class="itemLinkClass"
+      :is-collapsed="isCollapsed"
+      :has-tooltip="hasTooltip"
       v-bind="itemLinkAttributes"
       @click.native="clickEvent"
     >
@@ -34,9 +36,7 @@
         :appear="isMobileItem"
       >
         <template v-if="(isCollapsed && !isFirstLevel) || !isCollapsed || isMobileItem">
-          <span class="vsm--title" :title="isCollapsed && hasTooltip ? item.title : ''" >
-            {{ item.title }}
-          </span>
+          <span class="vsm--title">{{ item.title }}</span>
         </template>
       </transition>
       <template v-if="(isCollapsed && !isFirstLevel) || !isCollapsed || isMobileItem">

--- a/src/components/SidebarMenuLink.vue
+++ b/src/components/SidebarMenuLink.vue
@@ -1,6 +1,7 @@
 <template>
   <component
     :is="tag"
+    :title="isCollapsed && hasTooltip ? item.title : ''"
     v-bind="componentAttrs"
   >
     <slot />
@@ -15,6 +16,14 @@ export default {
     item: {
       type: Object,
       required: true
+    },
+    isCollapsed: {
+      type: Boolean,
+      default: false
+    },
+    hasTooltip: {
+      type: Boolean,
+      default: true
     }
   },
   computed: {


### PR DESCRIPTION
Users may need title as a tooltip when sidebar is collapsed as icon sometimes is not enough to completely understand what is item about. So I added html `title` attribute when sidebar is closed.