### PR TITLE
do auto scrollment when a parent node is at the bottom and expanded

### DIFF
--- a/src/components/SidebarMenuItem.vue
+++ b/src/components/SidebarMenuItem.vue
@@ -20,12 +20,12 @@
         : {}
     "
   >
-    <component
+    <component ref="menuItemRef"
       :is="linkComponentName ? linkComponentName : SidebarMenuLink"
       :item="item"
       :class="linkClass"
       v-bind="linkAttrs"
-      @click="onLinkClick"
+      @click="onMenuItemClick"
     >
       <template v-if="isCollapsed && isFirstLevel">
         <transition name="slide-animation">
@@ -55,14 +55,14 @@
       </div>
     </component>
     <template v-if="hasChild">
-      <transition
+      <!-- <transition
         :appear="isMobileItem"
         name="expand"
         @enter="onExpandEnter"
         @after-enter="onExpandAfterEnter"
         @before-leave="onExpandBeforeLeave"
         @after-leave="onExpandAfterLeave"
-      >
+      > -->
         <div
           v-if="show"
           :class="['vsm--child', isMobileItem && 'vsm--child_mobile']"
@@ -84,7 +84,7 @@
             </sidebar-menu-item>
           </ul>
         </div>
-      </transition>
+      <!-- </transition> -->
     </template>
   </li>
 </template>
@@ -96,7 +96,7 @@ export default {
 </script>
 
 <script setup>
-import { ref, toRefs } from 'vue'
+import { ref, toRefs, nextTick } from 'vue'
 import { useSidebar } from '../use/useSidebar'
 import useItem from '../use/useItem'
 
@@ -121,12 +121,30 @@ const props = defineProps({
 
 const emits = defineEmits(['update-active-show'])
 
-const { getSidebarProps, getIsCollapsed: isCollapsed } = useSidebar()
+const { getSidebarRef, getSidebarProps, getIsCollapsed: isCollapsed } = useSidebar()
 const { linkComponentName } = toRefs(getSidebarProps)
 const subActiveShow = ref(undefined)
 
+const menuItemRef = ref(null)
+
 const updateActiveShow = (id) => {
   subActiveShow.value = id
+}
+
+function onMenuItemClick(event) {
+
+  const vsmItemEl = menuItemRef.value.$parent.$el;
+  let showBeforeClick = show.value
+
+  onLinkClick(event)
+
+  if(hasChild.value == true && showBeforeClick == false && vsmItemEl.getBoundingClientRect().top>getSidebarRef.value.clientHeight*2/3 )
+  {
+    nextTick(() => {
+      vsmItemEl.scrollIntoView({ behavior: "smooth", block: "center" });
+    })
+  }
+
 }
 
 const {

--- a/src/components/SidebarMenuScroll.vue
+++ b/src/components/SidebarMenuScroll.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="vsm--scroll-wrapper"
-    @mousemove="onMouseIn"
+    @mouseenter="onMouseIn"
     @mouseleave="onMouseLeave"
   >
     <div ref="scrollRef" class="vsm--scroll" @scroll="onScroll">

--- a/src/use/useItem.js
+++ b/src/use/useItem.js
@@ -181,6 +181,7 @@ export default function useItem(props, emits) {
         }
       }
       itemShow.value = show
+      emitScrollUpdate()
     },
   })
 


### PR DESCRIPTION
    When a parent node is at the bottom of the sidebar and is clicked to expand children, the parent node and its children had better to be scrolled to the center in the sidebar.
    In the demo, for example, click 'Multiple Level' and 'Another Level 2', the children of the 'Another Level 2' are expanded but cannot be showed in the view, you need to scroll and show them.
    The commit did the job to add a method onMenuItemClick to do the auto scroll.
    <transition></transition> was commented because the animation lasted an interval to finish, I have to use setTimeout to calculate the element height and run the scroll, it is not so graceful. In my opinion, animation here does not take much advantage compared to the major function.