### PR TITLE
scroll when a parent node is at the bottom and after it is expanded

### DIFF
--- a/src/use/useItem.js
+++ b/src/use/useItem.js
@@ -1,4 +1,4 @@
-import { getCurrentInstance, computed, ref, inject, watch } from 'vue'
+import { getCurrentInstance, computed, ref, inject, watch, nextTick } from 'vue'
 import { useSidebar } from '../use/useSidebar'
 import {
   activeRecordIndex,
@@ -9,6 +9,7 @@ import {
 export default function useItem(props, emits) {
   const router = getCurrentInstance().appContext.config.globalProperties.$router
   const {
+    getSidebarRef,
     getSidebarProps: sidebarProps,
     getIsCollapsed: isCollapsed,
     getMobileItem: mobileItem,
@@ -137,6 +138,12 @@ export default function useItem(props, emits) {
   const onExpandAfterEnter = (el) => {
     el.style.height = 'auto'
     if (!isCollapsed.value) {
+      if(el.getBoundingClientRect().top>getSidebarRef.value.clientHeight*2/3 )
+      {
+        nextTick(() => {
+          el.parentNode.firstElementChild.scrollIntoView({ behavior: "smooth", block: "center" });
+        })
+      }
       emitScrollUpdate()
     }
   }


### PR DESCRIPTION
When a parent node is at the bottom of the sidebar and is clicked to expand its children, the parent node and its children had better to be scrolled to the center in the sidebar.
In the demo, for example, click 'Multiple Level' and 'Another Level 2', the children of the 'Another Level 2' are expanded but cannot be showed in the view, we need to scroll and show them.
The commit did the job to add the operation in onExpandAfterEnter.