### PR TITLE
add a method onMenuItemClick to do the auto scroll

### DIFF
--- a/src/components/SidebarMenuItem.vue
+++ b/src/components/SidebarMenuItem.vue
@@ -20,12 +20,12 @@
         : {}
     "
   >
-    <component
+    <component ref="menuItemRef"
       :is="linkComponentName ? linkComponentName : SidebarMenuLink"
       :item="item"
       :class="linkClass"
       v-bind="linkAttrs"
-      @click="onLinkClick"
+      @click="onMenuItemClick"
     >
       <template v-if="isCollapsed && isFirstLevel">
         <transition name="slide-animation">
@@ -55,14 +55,14 @@
       </div>
     </component>
     <template v-if="hasChild">
-      <transition
+      <!-- <transition
         :appear="isMobileItem"
         name="expand"
         @enter="onExpandEnter"
         @after-enter="onExpandAfterEnter"
         @before-leave="onExpandBeforeLeave"
         @after-leave="onExpandAfterLeave"
-      >
+      > -->
         <div
           v-if="show"
           :class="['vsm--child', isMobileItem && 'vsm--child_mobile']"
@@ -84,7 +84,7 @@
             </sidebar-menu-item>
           </ul>
         </div>
-      </transition>
+      <!-- </transition> -->
     </template>
   </li>
 </template>
@@ -96,13 +96,38 @@ export default {
 </script>
 
 <script setup>
-import { ref, toRefs } from 'vue'
+import { ref, toRefs, nextTick } from 'vue'
 import { useSidebar } from '../use/useSidebar'
 import useItem from '../use/useItem'
 
 import SidebarMenuLink from './SidebarMenuLink.vue'
 import SidebarMenuIcon from './SidebarMenuIcon.vue'
 import SidebarMenuBadge from './SidebarMenuBadge.vue'
+
+const menuItemRef = ref(null)
+
+function onMenuItemClick(event) {
+  const vsmItemEl = menuItemRef.value.$parent.$el.firstElementChild
+  console.log("menuItemRef:",vsmItemEl) 
+
+  console.log(vsmItemEl.getBoundingClientRect().top)
+
+  const { top: clickedItemTop } = vsmItemEl.getBoundingClientRect()
+  const { clientHeight: sideBarBottom } = getSidebarRef.value
+
+
+  let showBeforeClick = show.value
+
+  onLinkClick(event)
+  emitScrollUpdate()
+
+  if(hasChild.value == true && showBeforeClick == false && clickedItemTop>sideBarBottom*2/3 )
+  {
+    nextTick(() => {
+      vsmItemEl.scrollIntoView({ behavior: "smooth", block: "center" });
+    })
+  }
+}
 
 const props = defineProps({
   item: {
@@ -121,7 +146,7 @@ const props = defineProps({
 
 const emits = defineEmits(['update-active-show'])
 
-const { getSidebarProps, getIsCollapsed: isCollapsed } = useSidebar()
+const {getSidebarRef, getSidebarProps, getIsCollapsed: isCollapsed } = useSidebar()
 const { linkComponentName } = toRefs(getSidebarProps)
 const subActiveShow = ref(undefined)
 
@@ -148,9 +173,6 @@ const {
   onMouseOut,
   onMouseEnter,
   onMouseLeave,
-  onExpandEnter,
-  onExpandAfterEnter,
-  onExpandBeforeLeave,
-  onExpandAfterLeave,
+  emitScrollUpdate,
 } = useItem(props, emits)
 </script>

--- a/src/use/useItem.js
+++ b/src/use/useItem.js
@@ -9,7 +9,6 @@ import {
 export default function useItem(props, emits) {
   const router = getCurrentInstance().appContext.config.globalProperties.$router
   const {
-    getSidebarRef,
     getSidebarProps: sidebarProps,
     getIsCollapsed: isCollapsed,
     getMobileItem: mobileItem,
@@ -128,44 +127,6 @@ export default function useItem(props, emits) {
           unsetMobileItem(false, !isFirstLevel.value ? 300 : undefined)
         }
       }, 0)
-    }
-  }
-
-  const onExpandEnter = (el) => {
-    el.style.height = el.scrollHeight + 'px'
-  }
-
-  const onExpandAfterEnter = (el) => {
-    el.style.height = 'auto'
-
-    if (!isCollapsed.value) {
-      const sidebarWrapper = getSidebarRef.value.children[0]
-      const { bottom: collapseBottom } = el.getBoundingClientRect()
-      const { bottom: wrapperBottom } = sidebarWrapper.getBoundingClientRect()
-      if (collapseBottom > wrapperBottom) {
-        nextTick(() => {
-          el.scrollIntoView({
-            behavior: 'smooth',
-            block: 'end',
-          })
-        })
-      }
-
-      emitScrollUpdate()
-    }
-  }
-
-  const onExpandBeforeLeave = (el) => {
-    if (isCollapsed.value && isFirstLevel.value) {
-      el.style.display = 'none'
-      return
-    }
-    el.style.height = el.scrollHeight + 'px'
-  }
-
-  const onExpandAfterLeave = () => {
-    if (!isCollapsed.value) {
-      emitScrollUpdate()
     }
   }
 
@@ -350,9 +311,6 @@ export default function useItem(props, emits) {
     onMouseOut,
     onMouseEnter,
     onMouseLeave,
-    onExpandEnter,
-    onExpandAfterEnter,
-    onExpandBeforeLeave,
-    onExpandAfterLeave,
+    emitScrollUpdate,
   }
 }


### PR DESCRIPTION
Try to resolve the findings in the pull request #292: enhance testing method: add more level 2 nodes under multiple level node 
But unfortunately <transition></transition> was commented because the animation lasted an interval to finish, I have to use setTimeout to calculate the element height and run the scroll, it is not so graceful. In my opinion, animation here does not take much advantage compared to the major function. I tried my best to keep it.