### PR TITLE
feat: add dark theme and rename white-theme to light (deprecate white)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ props: {
     default: false
   },
 
-  // Sidebar theme (available themes: 'white-theme')
+  // Sidebar theme (available themes: 'light-theme', 'dark-theme')
   theme: {
     type: String,
     default: ''
@@ -270,6 +270,25 @@ All styles customization can be done in normal CSS by using this classes
 ## Theming
 
 You can create your own theme with SCSS or, you can edit the locally scoped CSS variables.
+
+### Deprecation: `white-theme` → `light-theme`
+
+The `white-theme` name is deprecated. Please use `light-theme` instead.
+
+- New names: `light-theme`, `dark-theme`
+- Old name: `white-theme` (still works for now for backward compatibility via `src/scss/themes/white-theme.scss`), but will be removed in a future major release.
+
+If you were previously using:
+
+```html
+<sidebar-menu :menu="menu" theme="white-theme" />
+```
+
+Update to:
+
+```html
+<sidebar-menu :menu="menu" theme="light-theme" />
+```
 
 **Sass variables:** (complete list of all variables can be found in `src/scss/_variables.scss`)
 

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -195,11 +195,15 @@ export default {
           input: '',
         },
         {
-          name: 'White theme',
-          input: 'white-theme',
+          name: 'Light theme',
+          input: 'light-theme',
+        },
+        {
+          name: 'Dark theme',
+          input: 'dark-theme',
         },
       ],
-      selectedTheme: 'white-theme',
+      selectedTheme: 'light-theme',
       isOnMobile: false,
     }
   },

--- a/demo/src/components/Props.vue
+++ b/demo/src/components/Props.vue
@@ -58,7 +58,7 @@
     default: false
   },
 
-  // Sidebar theme (available themes: 'white-theme')
+  // Sidebar theme (available themes: 'light-theme', 'dark-theme')
   theme: {
     type: String,
     default: ''

--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -81,7 +81,7 @@ const props = defineProps({
   theme: {
     type: String,
     default: undefined,
-    validator: (value) => ['', 'white-theme'].includes(value),
+    validator: (value) => ['', 'light-theme', 'dark-theme'].includes(value),
   },
   showOneChild: {
     type: [Boolean, String],

--- a/src/scss/themes/dark-theme.scss
+++ b/src/scss/themes/dark-theme.scss
@@ -1,0 +1,24 @@
+@use "sass:color";
+@use './_theme' as theme;
+
+.v-sidebar-menu.vsm_dark-theme {
+  --vsm-base-bg: #1e1e21;
+  --vsm-item-color: #ffffff;
+  --vsm-item-hover-bg: #{rgba(color.adjust(#1e1e21, $lightness: 8%), 0.18)};
+  --vsm-icon-bg: #2a2a2e;
+  --vsm-icon-active-color: #fff;
+  --vsm-icon-active-bg: var(--vsm-primary-color, #4285f4);
+  --vsm-dropdown-bg: #2a2a2e;
+  --vsm-header-item-color: #{rgba(#ffffff, 0.7)};
+  --vsm-toggle-btn-color: var(--vsm-item-color);
+  --vsm-toggle-btn-bg: #2a2a2e;
+  --vsm-badge-color: var(--vsm-item-color);
+  --vsm-badge-bg: #{rgba(#ffffff, 0.08)};
+
+  /* active/open defaults for dark theme */
+  --vsm-item-active-line-color: var(--vsm-primary-color, #4285f4);
+  --vsm-item-open-bg: var(--vsm-primary-color, #4285f4);
+  --vsm-mobile-item-bg: var(--vsm-primary-color, #4285f4);
+
+  @include theme.sidebar-theme;
+}

--- a/src/scss/themes/light-theme.scss
+++ b/src/scss/themes/light-theme.scss
@@ -1,8 +1,7 @@
-/* DEPRECATED: use 'light-theme.scss' and theme="light-theme" instead. This file remains for backward compatibility. */
 @use "sass:color";
-@use './theme' as theme;
+@use './_theme' as theme;
 
-.v-sidebar-menu.vsm_white-theme {
+.v-sidebar-menu.vsm_light-theme {
   --vsm-base-bg: #fff;
   --vsm-item-color: #262626;
   --vsm-item-hover-bg: #{rgba(color.adjust(#fff, $lightness: -5%), 0.5)};

--- a/src/scss/vue-sidebar-menu.scss
+++ b/src/scss/vue-sidebar-menu.scss
@@ -5,4 +5,5 @@
 
 // themes
 @forward './themes/default-theme';
-@forward './themes/white-theme';
+@forward './themes/light-theme';
+@forward './themes/dark-theme';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -126,10 +126,10 @@ export class SidebarMenu {
   hideToggle?: boolean;
 
   /**
-   * Sidebar theme (available themes: 'white-theme').
+   * Sidebar theme (available themes: 'light-theme', 'dark-theme').
    *
    */
-  theme?: '' | 'white-theme';
+  theme?: '' | 'light-theme' | 'dark-theme';
 
   /**
    * Disable hover on collapse mode.


### PR DESCRIPTION
This PR adds a dark theme, renames the old 'white-theme' to 'light-theme' for consistency, and updates docs & demo.\n\nChanges:\n- New SCSS: src/scss/themes/dark-theme.scss\n- Rename: 'white-theme' -> 'light-theme' (validator, types, demo)\n- Keep: src/scss/themes/white-theme.scss with deprecation header for backward compatibility\n- Docs: README ‘Theming’ section with migration note (white -> light)\n\nNotes:\n- The main SCSS forwards 'default', 'light', and 'dark'.\n- Existing users of  continue to work, but should migrate to .