### PR TITLE
Add toggleDropdownOnIconOnly prop to allow parent item menu with children to open only via the icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ menu: [
     // exact: true // apply active class when current route is exactly the same. (based on route records, query & hash are not relevant)
 
     // isActive: (item) => boolean | void // return a boolean to override the default active matcher
+
+    // toggleDropdownOnIconOnly: true // When you would like your parent item to act as a menu item whilst having the dropdown toggle on the icon only, you can set this to true.
   },
   // header item
   {

--- a/src/components/SidebarMenuItemLink.vue
+++ b/src/components/SidebarMenuItemLink.vue
@@ -41,6 +41,7 @@
         <div
           v-if="hasChild"
           :class="['vsm--arrow', { 'vsm--arrow_open': show }]"
+          @click.stop="onDropdownIconClick"
         >
           <slot name="dropdown-icon" v-bind="{ isOpen: show }" />
         </div>
@@ -204,9 +205,28 @@ const onLinkClick = (event: Event) => {
   emitMobileItem(event, (event.currentTarget as HTMLElement).parentElement!)
 
   if (hasChild.value) {
+    // Prevent toggling if toggleDropdownOnIconOnly is true
+    if (item.value.toggleDropdownOnIconOnly) {
+      emitItemClick(event, item.value)
+      return
+    }
+
     if (!item.value.href || active.value) {
       show.value = !show.value
     }
+  }
+
+  emitItemClick(event, item.value)
+}
+
+const onDropdownIconClick = (event: Event) => {
+  event.stopPropagation()
+  event.preventDefault()
+  if (item.value.disabled) return
+
+  // Only toggle dropdown, do not navigate
+  if (hasChild.value) {
+    show.value = !show.value
   }
 
   emitItemClick(event, item.value)
@@ -413,8 +433,20 @@ const mobileItemBackgroundStyle = computed<StyleValue>(() => ({
 
 watch(
   () => active.value,
-  () => {
-    if (active.value) show.value = true
+  (isActive, wasActive) => {
+    // Skip auto-opening if openDropdownOnIcon is true and the item has an href
+    if (
+      item.value.toggleDropdownOnIconOnly &&
+      item.value.href &&
+      !wasActive &&
+      isActive
+    ) {
+      return
+    }
+
+    if (isActive) {
+      show.value = true
+    }
   },
   { immediate: true }
 )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -98,6 +98,7 @@ export interface SidebarItem {
   exact?: boolean
   isActive?: (item: SidebarItem) => boolean
   id?: string
+  toggleDropdownOnIconOnly?: boolean
 }
 
 export interface SidebarHeaderItem {


### PR DESCRIPTION
**Summary**

This PR introduces a new prop, `toggleDropdownOnIconOnly`, to improve control over how parent menu items behave when they both navigate and contain child menu items.

**Background**

Previously, when a parent menu item had both a href and child menu items, clicking the parent would:
- Navigate to the given href
- Also toggle its dropdown open or closed

This dual behavior could be confusing for users who only expected the parent to navigate, assuming the dropdown icon was there to toggle the actual children menu items.

**New behavior**

When `toggleDropdownOnIconOnly` is true:
- Clicking the parent menu item navigates to its destination (if href is defined)
- Clicking the dropdown icon toggles the children submenu item list open or closed

**Example**

```
<sidebar-menu
  :menu="[
    {
       title: 'Settings',
       href: '/settings',
       child: [
         { title: 'Profile', href: '/settings/profile' },
         { title: 'Billing', href: '/settings/billing' }
       ],
       toggleDropdownOnIconOnly: true
    }
  ]"
/>
```

**Result**

- Clicking “Settings” → navigates to /settings
- Clicking the dropdown arrow → opens/closes the submenu

**Notes**

- Default behavior remains unchanged (backward-compatible)